### PR TITLE
Fix libretro_setbuffer warning

### DIFF
--- a/src/video/libretro/SDL_LIBRETROvideo.c
+++ b/src/video/libretro/SDL_LIBRETROvideo.c
@@ -579,7 +579,7 @@ static void LIBRETRO_UnlockHWSurface(_THIS, SDL_Surface *surface)
 	return;
 }
 
-extern libretro_setbuffer(void *pix,Uint16 x,Uint16 y){
+extern void libretro_setbuffer(void *pix,Uint16 x,Uint16 y){
 
 }
 


### PR DESCRIPTION
The function was defaulting to an int, but it should be a void.