### PR TITLE
warning: Fix implicit declaration of function

### DIFF
--- a/src/video/libretro/SDL_LIBRETROevents.c
+++ b/src/video/libretro/SDL_LIBRETROevents.c
@@ -29,6 +29,9 @@
 
 #include "libretro.h"
 
+void LIBRETRO_PumpMouse(_THIS);
+void LIBRETRO_PumpKeyboard(_THIS);
+
 void LIBRETRO_PumpEvents(_THIS)
 {
        // input_poll_cb();


### PR DESCRIPTION
This fixes two implicit declaration of function compilation warnings.