### PR TITLE
sdl-tetris: Fix crash at the exit

### DIFF
--- a/tests/sdl-tetris/libretro/libretro.c
+++ b/tests/sdl-tetris/libretro/libretro.c
@@ -464,7 +464,10 @@ void retro_deinit(void)
 
   LOGI("exit emu\n");
   co_switch(emuThread);
-
+  {
+    extern void SDL_Quit(void);
+    SDL_Quit();
+  }
   co_switch(mainThread);
   LOGI("exit main\n");
 

--- a/tests/sdl-tetris/main.c
+++ b/tests/sdl-tetris/main.c
@@ -172,8 +172,10 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "Unable to init SDL: %s\n", SDL_GetError());
 		exit(1);
 	}
+#ifndef __LIBRETRO__
 	// atexit : Quand on quittera (exit, return...), SDL_Quit() sera appelée.
 	atexit(SDL_Quit);
+#endif
 
 	// Video mode init.
 	Render_InitVideo();


### PR DESCRIPTION
SDL launches threads, this was the reason of the crash.